### PR TITLE
fix: Add cascade delete to RoutineExercise association

### DIFF
--- a/app/models/routine_exercise.rb
+++ b/app/models/routine_exercise.rb
@@ -1,6 +1,7 @@
 class RoutineExercise < ApplicationRecord
   belongs_to :routine
   belongs_to :exercise
+  has_many :workout_exercises, dependent: :destroy
 
   EXERCISE_GROUPS = {
     'regular' => 'Single exercise',


### PR DESCRIPTION
Fixes foreign key constraint violation when deleting routines that have associated workout_exercises. Adds proper cascade delete relationship: has_many :workout_exercises, dependent: :destroy

This ensures that when a routine_exercise is deleted, all associated workout_exercises are properly cleaned up, preventing FK violations.

Fixes #issue-with-routine-deletion