### PR TITLE
feat: implement admin user management functionality

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,7 +1,7 @@
 class User < ApplicationRecord
     has_secure_password
 
-    enum :role, { user: 0, coach: 1 }
+    enum :role, { user: 0, coach: 1, admin: 2 }
 
     # Relationships for coaches
     has_many :coach_users, foreign_key: :coach_id, dependent: :destroy
@@ -29,7 +29,7 @@ class User < ApplicationRecord
     private
     def role_must_be_valid
       if role.present? && !User.roles.keys.include?(role)
-        errors.add(:role, "Debe ser 'Usuario' o 'Entrenador'")
+        errors.add(:role, "Debe ser 'Usuario', 'Entrenador' o 'Administrador'")
       end
     end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -27,6 +27,13 @@ Rails.application.routes.draw do
   get "/auth/validate-token", to: "auth#validate_token"
   get "/profile", to: "users#profile"
 
+  # Admin routes - Admin only endpoints
+  namespace :admin do
+    get "/coaches", to: "users#index_coaches"
+    get "/users", to: "users#index_users"
+    post "/users", to: "users#create_by_admin"
+  end
+
   # Exercises
   get "/exercises", to: "exercises#index"
   get "/exercises/:id", to: "exercises#show"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -4,17 +4,16 @@
 
 puts "🌱 Starting database seeding..."
 
-# Create default trainer user
-trainer = User.find_or_create_by!(email: "trainer@smartlift.com") do |user|
+# Create default coach user
+coach = User.find_or_create_by!(email: "coach@smartlift.com") do |user|
   user.password = "password123"
   user.password_confirmation = "password123"
   user.first_name = "Demo"
-  user.last_name = "Trainer"
-  user.role = "trainer"
-  user.confirmed_at = Time.current
+  user.last_name = "Coach"
+  user.role = "coach"
 end
 
-puts "✅ Created trainer: #{trainer.email}"
+puts "✅ Created coach: #{coach.email}"
 
 # Create default basic user
 basic_user = User.find_or_create_by!(email: "user@smartlift.com") do |user|
@@ -23,9 +22,19 @@ basic_user = User.find_or_create_by!(email: "user@smartlift.com") do |user|
   user.first_name = "Demo"
   user.last_name = "User"
   user.role = "user"
-  user.confirmed_at = Time.current
 end
 
 puts "✅ Created basic user: #{basic_user.email}"
+
+# Create default admin user
+admin = User.find_or_create_by!(email: "admin@smartlift.com") do |user|
+  user.password = "password123"
+  user.password_confirmation = "password123"
+  user.first_name = "Demo"
+  user.last_name = "Admin"
+  user.role = "admin"
+end
+
+puts "✅ Created admin: #{admin.email}"
 
 puts "🎉 Database seeding completed!"


### PR DESCRIPTION
- Add admin role to User model enum (user, coach, admin)
- Add admin endpoints for user and coach management:
  - GET /admin/coaches - list all coaches
  - GET /admin/users - list all basic users
  - POST /admin/users - create users with specific roles
- Add admin authorization middleware (ensure_admin)
- Update seeds.rb to create default admin, coach, and user accounts
- Fix role names in seeding (coach instead of trainer)
- Remove non-existent confirmed_at field from seeds
- Add admin routes with proper namespace
- Implement secure role-based access control