### PR TITLE
fix: remove equipment field from exercise import task

### DIFF
--- a/lib/tasks/import_exercises.rake
+++ b/lib/tasks/import_exercises.rake
@@ -45,7 +45,6 @@ namespace :exercises do
               
               exercise.assign_attributes(
                 level: exercise_data["level"],
-                equipment: exercise_data["equipment"],
                 instructions: exercise_data["instructions"] || [],
                 primary_muscles: exercise_data["primaryMuscles"] || [],
                 images: full_image_urls


### PR DESCRIPTION
- Remove equipment field reference that doesn't exist in database schema
- Import task now only uses fields that exist: level, instructions, primary_muscles, images

