### PR TITLE
fix: add Railway domain to CORS allowed origins

### DIFF
--- a/config/initializers/cors.rb
+++ b/config/initializers/cors.rb
@@ -14,7 +14,8 @@ Rails.application.config.middleware.insert_before 0, Rack::Cors do
             "http://127.0.0.1:3000",
             "http://10.0.2.2:3000",  # Android emulator
             "http://localhost:19000", # Expo default
-            "http://localhost:19006"  # Expo web
+            "http://localhost:19006", # Expo web
+            "https://protective-mercy-dev.up.railway.app" # Railway deployment
     resource "*",
       headers: :any,
       methods: [ :get, :post, :put, :patch, :delete, :options, :head ],


### PR DESCRIPTION
- Add https://protective-mercy-dev.up.railway.app to CORS configuration
- Resolves issue where POST requests were being converted to GET due to CORS restrictions
- Railway domain was missing from allowed origins after CORS configuration split in commit 10357c5

