### PR TITLE
feat: Add AI routine editing before validation

### DIFF
--- a/app/controllers/api/v1/routine_validations_controller.rb
+++ b/app/controllers/api/v1/routine_validations_controller.rb
@@ -126,6 +126,72 @@ class Api::V1::RoutineValidationsController < ApplicationController
     end
   end
 
+  # PUT /api/v1/routine_validations/:id/edit
+  # Edita una rutina IA pendiente y opcionalmente la valida
+  def edit
+    begin
+      unless @routine.pending_validation?
+        return render json: {
+          success: false,
+          error: "Solo se pueden editar rutinas pendientes de validación"
+        }, status: :unprocessable_entity
+      end
+
+      # Validar parámetros de edición
+      edit_errors = validate_edit_params
+      if edit_errors.any?
+        return render json: {
+          success: false,
+          error: "Datos de edición inválidos",
+          details: edit_errors
+        }, status: :bad_request
+      end
+
+      # Actualizar la rutina
+      if @routine.update(routine_edit_params)
+        # Si se especifica auto-validar después de editar
+        if params[:auto_validate] == true
+          @routine.validate_routine!(current_user, params[:validation_notes])
+        end
+
+        render json: {
+          success: true,
+          message: params[:auto_validate] ? "Rutina editada y validada exitosamente" : "Rutina editada exitosamente",
+          data: {
+            routine: @routine.as_json.merge(
+              validation_info: {
+                validation_status: @routine.validation_status,
+                validated_at: @routine.validated_at,
+                validation_notes: @routine.validation_notes
+              }
+            )
+          }
+        }, status: :ok
+      else
+        render json: {
+          success: false,
+          error: "Error al actualizar la rutina",
+          details: @routine.errors.full_messages
+        }, status: :unprocessable_entity
+      end
+
+    rescue ActiveRecord::RecordInvalid => e
+      render json: {
+        success: false,
+        error: "Error de validación",
+        details: e.record.errors.full_messages
+      }, status: :unprocessable_entity
+
+    rescue StandardError => e
+      Rails.logger.error "Error editing routine: #{e.message}"
+      render json: {
+        success: false,
+        error: "Error interno al editar la rutina",
+        details: e.message
+      }, status: :internal_server_error
+    end
+  end
+
   # POST /api/v1/routine_validations/:id/reject
   # Rechaza una rutina generada por IA
   def reject
@@ -178,6 +244,134 @@ class Api::V1::RoutineValidationsController < ApplicationController
   end
 
   private
+
+  def validate_edit_params
+    errors = []
+
+    # Validar que al menos un campo esté presente para editar
+    editable_fields = [:name, :description, :difficulty, :duration, :routine_exercises_attributes]
+    has_editable_field = editable_fields.any? { |field| params[field].present? }
+
+    unless has_editable_field
+      errors << "Debe especificar al menos un campo para editar"
+      return errors
+    end
+
+    # Validar name si está presente
+    if params[:name].present?
+      if params[:name].to_s.length < 3
+        errors << "El nombre debe tener al menos 3 caracteres"
+      elsif params[:name].to_s.length > 100
+        errors << "El nombre no puede tener más de 100 caracteres"
+      end
+    end
+
+    # Validar description si está presente
+    if params[:description].present?
+      if params[:description].to_s.length < 10
+        errors << "La descripción debe tener al menos 10 caracteres"
+      elsif params[:description].to_s.length > 1000
+        errors << "La descripción no puede tener más de 1000 caracteres"
+      end
+    end
+
+    # Validar difficulty si está presente
+    if params[:difficulty].present?
+      unless %w[beginner intermediate advanced].include?(params[:difficulty].to_s)
+        errors << "La dificultad debe ser: beginner, intermediate o advanced"
+      end
+    end
+
+    # Validar duration si está presente
+    if params[:duration].present?
+      duration_int = params[:duration].to_i
+      if duration_int <= 0 || duration_int > 180
+        errors << "La duración debe estar entre 1 y 180 minutos"
+      end
+    end
+
+    # Validar routine_exercises_attributes si está presente
+    if params[:routine_exercises_attributes].present?
+      unless params[:routine_exercises_attributes].is_a?(Array)
+        errors << "Los ejercicios deben ser un array"
+      else
+        params[:routine_exercises_attributes].each_with_index do |exercise_attrs, index|
+          exercise_errors = validate_routine_exercise_attributes(exercise_attrs, index)
+          errors.concat(exercise_errors)
+        end
+      end
+    end
+
+    errors
+  end
+
+  def validate_routine_exercise_attributes(attrs, index)
+    errors = []
+
+    # Si es para eliminar, solo validar que tenga _destroy
+    if attrs[:_destroy] == "1" || attrs[:_destroy] == true
+      return errors
+    end
+
+    # Validar exercise_id
+    if attrs[:exercise_id].blank?
+      errors << "Ejercicio #{index + 1}: exercise_id es requerido"
+    elsif attrs[:exercise_id].to_i <= 0
+      errors << "Ejercicio #{index + 1}: exercise_id debe ser un entero positivo"
+    end
+
+    # Validar sets
+    if attrs[:sets].present?
+      sets_int = attrs[:sets].to_i
+      if sets_int <= 0 || sets_int > 20
+        errors << "Ejercicio #{index + 1}: sets debe estar entre 1 y 20"
+      end
+    end
+
+    # Validar reps
+    if attrs[:reps].present?
+      reps_int = attrs[:reps].to_i
+      if reps_int <= 0 || reps_int > 100
+        errors << "Ejercicio #{index + 1}: reps debe estar entre 1 y 100"
+      end
+    end
+
+    # Validar rest_time si está presente
+    if attrs[:rest_time].present?
+      rest_time_int = attrs[:rest_time].to_i
+      if rest_time_int < 0 || rest_time_int > 600
+        errors << "Ejercicio #{index + 1}: rest_time debe estar entre 0 y 600 segundos"
+      end
+    end
+
+    # Validar order si está presente
+    if attrs[:order].present?
+      order_int = attrs[:order].to_i
+      if order_int <= 0
+        errors << "Ejercicio #{index + 1}: order debe ser un entero positivo"
+      end
+    end
+
+    errors
+  end
+
+  def routine_edit_params
+    params.permit(
+      :name,
+      :description,
+      :difficulty,
+      :duration,
+      routine_exercises_attributes: [
+        :id,
+        :exercise_id,
+        :sets,
+        :reps,
+        :rest_time,
+        :order,
+        :_destroy
+      ]
+    )
+  end
 
   def find_routine
     # Obtener IDs de usuarios asignados al entrenador actual

--- a/app/controllers/exercises_controller.rb
+++ b/app/controllers/exercises_controller.rb
@@ -1,7 +1,7 @@
 class ExercisesController < ApplicationController
   # Authentication required for all operations for security
   before_action :set_exercise, only: [ :show, :update, :destroy ]
-  before_action :ensure_coach_or_admin, only: [ :create, :update, :destroy ]
+  before_action :ensure_coach_or_admin, only: [ :create, :update, :destroy, :update_video_url ]
 
   # GET /exercises
   def index
@@ -49,6 +49,25 @@ class ExercisesController < ApplicationController
     head :no_content
   end
 
+  # PUT /exercises/:id/video_url
+  def update_video_url
+    @exercise = Exercise.find(params[:id])
+    
+    if @exercise.update(video_url: params[:video_url])
+      render json: {
+        message: "Video URL updated successfully",
+        exercise: @exercise.as_json(methods: [:difficulty_level])
+      }, status: :ok
+    else
+      render json: { 
+        error: "Failed to update video URL",
+        details: @exercise.errors.full_messages 
+      }, status: :unprocessable_entity
+    end
+  rescue ActiveRecord::RecordNotFound
+    render json: { error: "Exercise not found" }, status: :not_found
+  end
+
   private
 
   def set_exercise
@@ -62,6 +81,7 @@ class ExercisesController < ApplicationController
       :name,
       :level,
       :instructions,
+      :video_url,
       primary_muscles: [],
       images: []
     )

--- a/app/models/exercise.rb
+++ b/app/models/exercise.rb
@@ -2,6 +2,7 @@ class Exercise < ApplicationRecord
     # Validaciones actualizadas para el import de free-exercise-db
     validates :name, presence: true, uniqueness: true
     validates :level, inclusion: { in: %w[beginner intermediate expert] }, allow_nil: true
+    validates :video_url, format: { with: URI::DEFAULT_PARSER.make_regexp(%w[http https]), message: "must be a valid URL" }, allow_blank: true
     # Removemos la validación de id numérico ya que el JSON usa strings como identificadores
 
     # Scopes para búsquedas comunes

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -74,6 +74,7 @@ Rails.application.routes.draw do
   post "/exercises", to: "exercises#create"
   patch "/exercises/:id", to: "exercises#update"
   delete "/exercises/:id", to: "exercises#destroy"
+  put "/exercises/:id/video_url", to: "exercises#update_video_url"
 
   # User Stats
   get "/user_stats", to: "user_stats#index"
@@ -142,6 +143,7 @@ Rails.application.routes.draw do
         member do
           post :approve
           post :reject
+          put :edit
         end
       end
 

--- a/db/migrate/20250819221607_add_video_url_to_exercises.rb
+++ b/db/migrate/20250819221607_add_video_url_to_exercises.rb
@@ -1,0 +1,5 @@
+class AddVideoUrlToExercises < ActiveRecord::Migration[7.1]
+  def change
+    add_column :exercises, :video_url, :string
+  end
+end

--- a/db/migrate/20250819221637_add_video_url_to_exercises.rb
+++ b/db/migrate/20250819221637_add_video_url_to_exercises.rb
@@ -1,0 +1,6 @@
+class AddVideoUrlToExercises < ActiveRecord::Migration[7.1]
+  def change
+    add_column :exercises, :video_url, :string
+    add_index :exercises, :video_url
+  end
+end


### PR DESCRIPTION
- Add PUT /api/v1/routine_validations/:id/edit endpoint
- Allow trainers to edit pending AI routines
- Support nested routine_exercises_attributes
- Add auto_validate parameter for immediate approval
- Implement comprehensive validation and error handling
- Restrict editing to pending_validation status only
- Maintain trainer authorization and access control